### PR TITLE
<del> @rend="parens"

### DIFF
--- a/epidoc.xsg
+++ b/epidoc.xsg
@@ -825,7 +825,8 @@ figure
 del_rend
 	: [del_rend_cross drc] = [del_rend_cross drc]
 	>: [del_rend_slashes drs] = [del_rend_slashes drs]
-	>: [del_rend_erasure dre] = [del_rend_erasure dre]
+	>: [del_rend_parens drp] = [del_rend_parens drp]
+  >: [del_rend_erasure dre] = [del_rend_erasure dre]
 
 	//---del_rend_cross---
 	//  〚Xwhatever〛, 〚Xwhatever(?)〛
@@ -838,6 +839,12 @@ del_rend_cross
 del_rend_slashes
 	>: "〚\/" [items a] "〛" = <del rend="slashes">[items a]</>
 	>: "〚\/" [items a] "(?)" "〛" = <del rend="slashes">[items a]<certainty match=".." locus="value"/></>
+
+  //---del_rend_parens---
+	//  〚(whatever)〛, 〚(whatever(?))〛
+del_rend_parens
+	>: "〚\(" [items a] "\)〛" = <del rend="parens">[items a]</>
+	>: "〚\(" [items a] "(?)" "\)〛" = <del rend="parens">[items a]<certainty match=".." locus="value"/></>
 
 //this one has to be last so the first case will be caught before get here because '-' is a valid WORDS character
 	//---del_rend_erasure---


### PR DESCRIPTION
Scribes occasionally use parentheses to indicate deletion, and this update defines Leiden+ for `<del>` `@rend="parens"`. Please note rows `846` and `847`, where I have canceled the opening and closing parentheses inside double brackets; I was unsure whether it was necessary to do so and added them to be safe. 

Via a separate request, I will add support to the EpiDoc stylesheet so as to produce the correct apparatus entry in PN.