### PR TITLE
Adding support for `@rend` values on `g[@type="check"]`

### DIFF
--- a/epidoc.xsg
+++ b/epidoc.xsg
@@ -825,7 +825,8 @@ figure
 del_rend
 	: [del_rend_cross drc] = [del_rend_cross drc]
 	>: [del_rend_slashes drs] = [del_rend_slashes drs]
-	>: [del_rend_erasure dre] = [del_rend_erasure dre]
+	>: [del_rend_parens drp] = [del_rend_parens drp]
+  >: [del_rend_erasure dre] = [del_rend_erasure dre]
 
 	//---del_rend_cross---
 	//  〚Xwhatever〛, 〚Xwhatever(?)〛
@@ -838,6 +839,12 @@ del_rend_cross
 del_rend_slashes
 	>: "〚\/" [items a] "〛" = <del rend="slashes">[items a]</>
 	>: "〚\/" [items a] "(?)" "〛" = <del rend="slashes">[items a]<certainty match=".." locus="value"/></>
+
+  //---del_rend_parens---
+	//  〚(whatever)〛, 〚(whatever(?))〛
+del_rend_parens
+	>: "〚\(" [items a] "\)〛" = <del rend="parens">[items a]</>
+	>: "〚\(" [items a] "(?)" "\)〛" = <del rend="parens">[items a]<certainty match=".." locus="value"/></>
 
 //this one has to be last so the first case will be caught before get here because '-' is a valid WORDS character
 	//---del_rend_erasure---

--- a/epidoc.xsg
+++ b/epidoc.xsg
@@ -841,7 +841,7 @@ del_rend_slashes
 	>: "〚\/" [items a] "〛" = <del rend="slashes">[items a]</>
 	>: "〚\/" [items a] "(?)" "〛" = <del rend="slashes">[items a]<certainty match=".." locus="value"/></>
 
-    //this one has to be last so the first case will be caught before get here because '-' is a valid WORDS character
+//this one has to be last so the first case will be caught before get here because '-' is a valid WORDS character
 	//---del_rend_erasure---
 	//  〚whatever〛, 〚whatever(?)〛
 del_rend_erasure

--- a/epidoc.xsg
+++ b/epidoc.xsg
@@ -781,12 +781,14 @@ rdg_stuff
 glyph
 	: "*" [WORD k] "?*" = <unclear><g type=[WORD k]></></>
 	: "*filler(" [WORD a] ")?*" = <unclear><g rend=[WORD a] type="filler"></></>
+	: "*check(" [WORD a] ")?*" = <unclear><g rend=[WORD a] type="check"></></>
 	: "*" [WORD a] "*" = <g type=[WORD a]></>
 	: "*" [WORD a] "," [WORD b] "*" = <g type=[WORD a]>[WORD b]</>
 	>: "*" [WORD a] "," [items b] "*" = <g type=[WORD a]>[items b]</>
 	: "*" [WORD a] "?," [WORD b] "*" = <unclear><g type=[WORD a]>[WORD b]</></>
 	>: "*" [WORD a] "?," [items b] "*" = <unclear><g type=[WORD a]>[items b]</></>
 	: "*filler(" [WORD a] ")" "*" = <g rend=[WORD a] type="filler"></>
+	: "*check(" [WORD a] ")" "*" = <g rend=[WORD a] type="check"></>
 
 	//---hand_shift---
 	//  "$m1 ", "$m1(?) " - space afterward required

--- a/epidoc.xsg
+++ b/epidoc.xsg
@@ -827,8 +827,7 @@ figure
 del_rend
 	: [del_rend_cross drc] = [del_rend_cross drc]
 	>: [del_rend_slashes drs] = [del_rend_slashes drs]
-	>: [del_rend_parens drp] = [del_rend_parens drp]
-  >: [del_rend_erasure dre] = [del_rend_erasure dre]
+	>: [del_rend_erasure dre] = [del_rend_erasure dre]
 
 	//---del_rend_cross---
 	//  〚Xwhatever〛, 〚Xwhatever(?)〛
@@ -842,13 +841,7 @@ del_rend_slashes
 	>: "〚\/" [items a] "〛" = <del rend="slashes">[items a]</>
 	>: "〚\/" [items a] "(?)" "〛" = <del rend="slashes">[items a]<certainty match=".." locus="value"/></>
 
-  //---del_rend_parens---
-	//  〚(whatever)〛, 〚(whatever(?))〛
-del_rend_parens
-	>: "〚\(" [items a] "\)〛" = <del rend="parens">[items a]</>
-	>: "〚\(" [items a] "(?)" "\)〛" = <del rend="parens">[items a]<certainty match=".." locus="value"/></>
-
-//this one has to be last so the first case will be caught before get here because '-' is a valid WORDS character
+    //this one has to be last so the first case will be caught before get here because '-' is a valid WORDS character
 	//---del_rend_erasure---
 	//  〚whatever〛, 〚whatever(?)〛
 del_rend_erasure


### PR DESCRIPTION
Moving forward, we would like to be able to distinguish between different `@rend` values of `g[@type="check"]`, because these sometimes appear as `/`, sometimes as `☓`, and sometimes as `•` (an example where it already appears is [P.Oxy. 84.5466](https://github.com/papyri/idp.data/blob/0c9bdc86f2b5408f8006f4aaaef40a809b12ee6c/DDB_EpiDoc_XML/p.oxy/p.oxy.84/p.oxy.84.5466.xml#L100)). I have therefore updated XSugar to provide Leiden+, which is modeled on the existing XSugar for `g[@type="filler"]`, which has different possible `@rend` values e.g., `*filler(extension)*` and `*filler(diple)*`, where the `@rend` value is placed inside parentheses in Leiden+.

I haven't the capacity to test XSugar locally, but it's only a small bit code paralleled a few lines above. Please test before pushing to production.

Once the Leiden+ is in place, I will make sure that these characters are supported in EpiDoc stylesheets. 

@hcayless, please keep the cases of `g[@type="filler"]` and `g[@type="check"]` in mind as you contemplate the future conversion from `@type` to `@rend`, which I know is on your mind.